### PR TITLE
-Restore: don't reset settings when going back to an older version

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3179,7 +3179,7 @@ static int MenuSettingsEmulation()
 		{
 			case 0:
 				GCSettings.GBHardware++;
-				if (GCSettings.GBHardware > 3)
+				if (GCSettings.GBHardware > 5)
 					GCSettings.GBHardware = 0;
 				break;
 			

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -469,9 +469,6 @@ decodePrefsData ()
 					result = false;
 				else if(verMajor < 2) // less than version 2.0.0
 					result = false; // reset settings (sorry, should update settings instead)
-				else if((verMajor*100 + verMinor*10 + verPoint) > 
-						(curMajor*100 + curMinor*10 + curPoint)) // some future version
-					result = false; // reset settings
 				else
 					result = true;
 			}


### PR DESCRIPTION
-Adjust to display more options to GB Hardware type