### PR TITLE
Update preferences.cpp

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -813,7 +813,7 @@ bool LoadPrefs()
 		return true;
 
 	bool prefFound = false;
-	char filepath[4][MAXPATHLEN];
+	char filepath[5][MAXPATHLEN];
 	int numDevices;
 	
 #ifdef HW_RVL


### PR DESCRIPTION
on wii, it tries to access 5 elements (see line 825) even though filepath only holds 4 elements, meaning it overwrites part of the stack leading to random crashes etc.