### PR TITLE
Swapping preview images with + button

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -1021,7 +1021,7 @@ static int MenuGameSelection()
 		if(previousBrowserIndex != browser.selIndex)
 		{
 			previousBrowserIndex = browser.selIndex;
-			snprintf(imagePath, MAXJOLIET, "%s%s/%s.png", pathPrefix[GCSettings.LoadMethod], GCSettings.ImageFolder, browserList[browser.selIndex].displayname);
+			snprintf(imagePath, MAXJOLIET, "%s%s/%s.png", pathPrefix[GCSettings.LoadMethod], ImageFolder(), browserList[browser.selIndex].displayname);
 
 			AllocSaveBuffer();
 			int width, height;
@@ -3803,15 +3803,12 @@ static int MenuSettingsMenu()
 			{
 				case 0:	
 					sprintf(options.value[6], "Screenshots"); 
-					snprintf(GCSettings.ImageFolder, MAXJOLIET, "%s", GCSettings.ScreenshotsFolder);
 					break; 
 				case 1:	
 					sprintf(options.value[6], "Covers");	  
-					snprintf(GCSettings.ImageFolder, MAXJOLIET, "%s", GCSettings.CoverFolder);
 					break; 
 				case 2:	
 					sprintf(options.value[6], "Artwork");
-					snprintf(GCSettings.ImageFolder, MAXJOLIET, "%s", GCSettings.ArtworkFolder);
 					break; 
 			}
 			optionBrowser.TriggerUpdate();

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -928,8 +928,15 @@ static int MenuGameSelection()
 	gameBrowser.SetPosition(20, 98);
 	ResetBrowser();
 
+	GuiTrigger trigPlusMinus;
+	trigPlusMinus.SetButtonOnlyTrigger(-1, WPAD_BUTTON_PLUS | WPAD_CLASSIC_BUTTON_PLUS, PAD_TRIGGER_Z, WIIDRC_BUTTON_PLUS);
+
 	GuiImage bgPreview(&bgPreviewImg);
-	bgPreview.SetPosition(365, 98);
+	GuiButton bgPreviewBtn(bgPreview.GetWidth(), bgPreview.GetHeight());
+	bgPreviewBtn.SetImage(&bgPreview);
+	bgPreviewBtn.SetPosition(365, 98);
+	bgPreviewBtn.SetTrigger(&trigPlusMinus);
+	int previousPreviewImg = GCSettings.PreviewImage;
 	
 	GuiImage preview;
 	preview.SetAlignment(ALIGN_CENTRE, ALIGN_MIDDLE);
@@ -944,7 +951,7 @@ static int MenuGameSelection()
 	mainWindow->Append(&titleTxt);
 	mainWindow->Append(&gameBrowser);
 	mainWindow->Append(&buttonWindow);
-	mainWindow->Append(&bgPreview);
+	mainWindow->Append(&bgPreviewBtn);
 	mainWindow->Append(&preview);
 	ResumeGui();
 
@@ -1018,9 +1025,10 @@ static int MenuGameSelection()
 		}
 		
 		//update gamelist image
-		if(previousBrowserIndex != browser.selIndex)
+		if(previousBrowserIndex != browser.selIndex || previousPreviewImg != GCSettings.PreviewImage)
 		{
 			previousBrowserIndex = browser.selIndex;
+			previousPreviewImg = GCSettings.PreviewImage;
 			snprintf(imagePath, MAXJOLIET, "%s%s/%s.png", pathPrefix[GCSettings.LoadMethod], ImageFolder(), browserList[browser.selIndex].displayname);
 
 			AllocSaveBuffer();
@@ -1048,6 +1056,11 @@ static int MenuGameSelection()
 			menu = MENU_SETTINGS;
 		else if(exitBtn.GetState() == STATE_CLICKED)
 			ExitRequested = 1;
+		else if(bgPreviewBtn.GetState() == STATE_CLICKED)
+		{
+			GCSettings.PreviewImage = (GCSettings.PreviewImage + 1) % 3;
+			bgPreviewBtn.ResetState();
+		}
 	}
 
 	HaltParseThread(); // halt parsing
@@ -1056,7 +1069,7 @@ static int MenuGameSelection()
 	mainWindow->Remove(&titleTxt);
 	mainWindow->Remove(&buttonWindow);
 	mainWindow->Remove(&gameBrowser);
-	mainWindow->Remove(&bgPreview);
+	mainWindow->Remove(&bgPreviewBtn);
 	mainWindow->Remove(&preview);
 	MEM_DEALLOC(imgBuffer);
 	return menu;

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -174,7 +174,6 @@ preparePrefsData ()
 	createXMLSetting("BorderFolder", "SGB Borders Folder", GCSettings.BorderFolder);
 	createXMLSetting("CoverFolder", "Covers Folder", GCSettings.CoverFolder);
 	createXMLSetting("ArtworkFolder", "Artwork Folder", GCSettings.ArtworkFolder);
-	createXMLSetting("ImageFolder", "Image Folder", GCSettings.ImageFolder);
 
 	createXMLSection("Network", "Network Settings");
 
@@ -490,7 +489,6 @@ decodePrefsData ()
 			loadXMLSetting(GCSettings.BorderFolder, "BorderFolder", sizeof(GCSettings.BorderFolder));
 			loadXMLSetting(GCSettings.CoverFolder, "CoverFolder", sizeof(GCSettings.CoverFolder));
 			loadXMLSetting(GCSettings.ArtworkFolder, "ArtworkFolder", sizeof(GCSettings.ArtworkFolder));
-			loadXMLSetting(GCSettings.ImageFolder, "ImageFolder", sizeof(GCSettings.ImageFolder));
 
 			// Network Settings
 
@@ -638,7 +636,6 @@ DefaultSettings ()
 	sprintf (GCSettings.BorderFolder, "%s/borders", APPFOLDER);
 	sprintf (GCSettings.CoverFolder, "%s/covers", APPFOLDER); // Path to cover files
 	sprintf (GCSettings.ArtworkFolder, "%s/artwork", APPFOLDER); // Path to artwork files
-	sprintf (GCSettings.ImageFolder, "%s/screenshots", APPFOLDER);
 
 	GCSettings.AutoLoad = 1;
 	GCSettings.AutoSave = 1;

--- a/source/vbagx.cpp
+++ b/source/vbagx.cpp
@@ -469,3 +469,13 @@ int main(int argc, char *argv[])
 	} // main loop
 	return 0;
 }
+
+char* ImageFolder()
+{
+	switch(GCSettings.PreviewImage)
+	{
+		case 1 : return GCSettings.CoverFolder; break;
+		case 2 : return GCSettings.ArtworkFolder; break;
+		default: return GCSettings.ScreenshotsFolder; break;
+	}
+}

--- a/source/vbagx.h
+++ b/source/vbagx.h
@@ -107,7 +107,6 @@ struct SGCSettings
 	char	ScreenshotsFolder[MAXPATHLEN]; //Path to screenshots files
 	char	CoverFolder[MAXPATHLEN]; 	//Path to cover files
 	char	ArtworkFolder[MAXPATHLEN]; 	//Path to artwork files
-	char 	ImageFolder[MAXPATHLEN]; 	//Saved image folder path 
 	char	BorderFolder[MAXPATHLEN];  // Path to Super Game Boy border files
 
 	char	smbip[80];
@@ -115,6 +114,9 @@ struct SGCSettings
 	char	smbpwd[20];
 	char	smbshare[20];
 };
+
+char* ImageFolder();
+
 void ExitApp();
 void ShutdownWii();
 bool SupportedIOS(u32 ios);


### PR DESCRIPTION
Same changes than in snes9xgx

Getting into the menu settings and changing the preview image is a bit annoying when we can just swap images pressing one button
Also I have removed the ImageFolder char* since it can always be retrieved from GCSettings.PreviewImage