### PR TITLE
Refactor make files and change artifact output

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,9 +16,26 @@ jobs:
     - name: Build
       run: |
         make -j2
+    
+    - name: Copy files
+      run: | 
+        cp -f hbc/* executables/VisualBoyAdvanceGX/apps/vbagx/
+        cp -f hbc/* executables/VisualBoyAdvanceGX-GameCube/
+        cp -f README.md executables/VisualBoyAdvanceGX/apps/vbagx/
+        cp -f README.md executables/VisualBoyAdvanceGX-GameCube/
 
-    - name: Upload a Build Artifact
+    - name: Upload Wii Build Artifacts
       uses: actions/upload-artifact@v2
       with: 
-        name: executables
-        path: executables/*
+        name: VisualBoyAdvanceGX-Nightly
+        path: |
+         executables/VisualBoyAdvanceGX/
+         !executables/VisualBoyAdvanceGX/apps/vbagx/*.elf
+    
+    - name: Upload GameCube Build Artifacts
+      uses: actions/upload-artifact@v2
+      with: 
+        name: VisualBoyAdvanceGX-Nightly-GameCube
+        path: |
+         executables/VisualBoyAdvanceGX-GameCube/
+         !executables/VisualBoyAdvanceGX-GameCube/*.elf

--- a/Makefile.gc
+++ b/Makefile.gc
@@ -11,12 +11,13 @@ include $(DEVKITPPC)/gamecube_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
+# TARGETDIR is the directory where the output files will be placed
 # BUILD is the directory where object files & intermediate files will be placed
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	vbagx-gc
-TARGETDIR   :=  executables
+TARGET		:=	boot
+TARGETDIR   :=  executables/VisualBoyAdvanceGX-GameCube
 BUILD		:=	build_gc
 SOURCES		:=	source source/gui source/utils source/utils/sz \
 				source/vba source/vba/apu source/vba/common \
@@ -119,7 +120,7 @@ $(BUILD):
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol
+	@rm -fr $(BUILD) $(TARGETDIR)
 
 #---------------------------------------------------------------------------------
 run:

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -11,12 +11,17 @@ include $(DEVKITPPC)/wii_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
+# TARGETDIR is the directory where the output files will be placed
+# SUBDIR are the directories where the cheats, roms and saves need to be placed
+# ROOTDIR is the root directory of the build
 # BUILD is the directory where object files & intermediate files will be placed
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	vbagx-wii
-TARGETDIR   :=  executables
+TARGET		:=	boot
+TARGETDIR   :=  executables/VisualBoyAdvanceGX/apps/vbagx
+ROOTDIR		:=	executables/VisualBoyAdvanceGX
+SUBDIR		:=	executables/VisualBoyAdvanceGX/vbagx/{cheats,roms,saves}
 BUILD		:=	build_wii
 SOURCES		:=	source source/gui source/utils source/utils/sz \
 				source/vba source/vba/apu source/vba/common \
@@ -114,13 +119,13 @@ export OUTPUT	:=	$(CURDIR)/$(TARGETDIR)/$(TARGET)
 #---------------------------------------------------------------------------------
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@[ -d $(TARGETDIR) ] || mkdir -p $(TARGETDIR)
+	@[ -d $(TARGETDIR) ] || mkdir -p $(TARGETDIR) $(SUBDIR)
 	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.wii
 
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol
+	@rm -fr $(BUILD) $(ROOTDIR)
 
 #---------------------------------------------------------------------------------
 run:


### PR DESCRIPTION
This changes the following:
- Uploads a separate Wii and Gamecube artifact
- Excludes uploading the elf files
- Creates the complete Wii structure under executables/VisualBoyAdvanceGX
- Creates the complete GameCube structure under executables/VisualBoyAdvanceGX-GameCube
- Doesn't upload empty folders like the vbagx folder with cheats, roms and saves but it is created in a local environment