### PR TITLE
Add "Enable Turbo Mode" toggle to the Video Settings menu (based on InfiniteBlueGX's code)

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -880,11 +880,13 @@ static u32 DecodeJoy(unsigned short pad)
 	u32 J = StandardMovement(pad);
 
 	// Turbo feature
-	if(userInput[0].pad.substickX > 70 || 
-		userInput[0].WPAD_Stick(1,0) > 70 ||
-		userInput[0].wiidrcdata.substickX > 45)
-		J |= VBA_SPEED;
-
+	if (GCSettings.TurboModeEnabled == 1)
+	{
+		if(userInput[0].pad.substickX > 70 || 
+			userInput[0].WPAD_Stick(1,0) > 70 ||
+			userInput[0].wiidrcdata.substickX > 45)
+			J |= VBA_SPEED;
+	}
 	// Report pressed buttons (gamepads)
 	u32 pad_btns_h   = userInput[pad].pad.btns_h; // GCN
 	u32 wiidrcp_btns_h  = userInput[pad].wiidrcdata.btns_h;

--- a/source/lang/es.lang
+++ b/source/lang/es.lang
@@ -181,6 +181,9 @@ msgstr "Holandés"
 msgid "Enabled"
 msgstr "Activado"
 
+msgid "Enable Turbo Mode"
+msgstr "Activar Modo Turbo"
+
 msgid "English"
 msgstr "Inglés"
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3098,6 +3098,7 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "GB Mono Colorization");
 	sprintf(options.name[i++], "GB Palette");
 	sprintf(options.name[i++], "GBA Frameskip");
+	sprintf(options.name[i++], "Enable Turbo Mode");
 	options.length = i;
 
 	for(i=0; i < options.length; i++)
@@ -3208,6 +3209,11 @@ static int MenuSettingsVideo()
 			case 8:
 				GCSettings.gbaFrameskip ^= 1;
 				break;
+			case 9:
+				GCSettings.TurboModeEnabled++;
+				if (GCSettings.TurboModeEnabled > 1)
+					GCSettings.TurboModeEnabled = 0;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3289,7 +3295,7 @@ static int MenuSettingsVideo()
 				sprintf (options.value[8], "On");
 			else
 				sprintf (options.value[8], "Off");
-
+			sprintf (options.value[10], "%s", GCSettings.TurboModeEnabled == 1 ? "On" : "Off");
 			optionBrowser.TriggerUpdate();
 		}
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3295,7 +3295,7 @@ static int MenuSettingsVideo()
 				sprintf (options.value[8], "On");
 			else
 				sprintf (options.value[8], "Off");
-			sprintf (options.value[10], "%s", GCSettings.TurboModeEnabled == 1 ? "On" : "Off");
+			sprintf (options.value[9], "%s", GCSettings.TurboModeEnabled == 1 ? "On" : "Off");
 			optionBrowser.TriggerUpdate();
 		}
 

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -197,6 +197,7 @@ preparePrefsData ()
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
 	createXMLSetting("colorize", "Colorize Mono Gameboy", toStr(GCSettings.colorize));
 	createXMLSetting("gbaFrameskip", "GBA Frameskip", toStr(GCSettings.gbaFrameskip));
+	createXMLSetting("TurboModeEnabled", "Turbo Mode Enabled", toStr(GCSettings.TurboModeEnabled));
 
 	createXMLSection("Menu", "Menu Settings");
 
@@ -512,6 +513,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.yshift, "yshift");
 			loadXMLSetting(&GCSettings.colorize, "colorize");
 			loadXMLSetting(&GCSettings.gbaFrameskip, "gbaFrameskip");
+			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
 
 			// Menu Settings
 
@@ -658,6 +660,7 @@ DefaultSettings ()
 	GCSettings.yshift = 0; // vertical video shift
 	GCSettings.colorize = 0; // Colorize mono gameboy games
 	GCSettings.gbaFrameskip = 1; // Turn auto-frameskip on for GBA games
+	GCSettings.TurboModeEnabled = 1; // Enabled by default
 
 	GCSettings.WiimoteOrientation = 0;
 	GCSettings.ExitAction = 0;

--- a/source/vbagx.h
+++ b/source/vbagx.h
@@ -95,6 +95,7 @@ struct SGCSettings
 	int		Rumble;
 	int 	language;
 	int		PreviewImage;
+	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 	int		AutoloadGame;
 	
 	int		OffsetMinutesUTC; // Used for clock on MBC3 and TAMA5


### PR DESCRIPTION
So I got inspired by this [pull request](https://github.com/dborth/snes9xgx/pull/1005) made to Snes9x GX made by @InfiniteBlueGX for add the posibility to enable or disable the Turbo Mode feature.

These changes added an option to the Video Settings menu to toggle on/off the "Turbo Mode" feature from the right analog stick. When disabled, holding the stick to the right does not activate Turbo Mode. The setting is enabled by default.

The setting is saved to XML and the user's choice persists upon application re-entry.

Like for FCEUGX, I had to modify a different file for make this work but it works like a charm.

This will be utile because for newer releases of VBAGX we won't need a separated build with disabled Turbo Mode, will need only to manually enable/disable it on Video Settings.