### PR TITLE
Update GitHub's "Upload Artifact Builds" plugin to v3.1.0 on workflow 

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -34,7 +34,7 @@ jobs:
         cp executables/vbagx-wii.dol dist/VisualBoyAdvanceGX/apps/vbagx/boot.dol
 
     - name: Upload Wii artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       if: ${{ matrix.image == 'Wii' }}
       with: 
         name: VisualBoyAdvanceGX
@@ -53,7 +53,7 @@ jobs:
         cp executables/vbagx-gc.dol dist/VisualBoyAdvanceGX-GameCube/
     
     - name: Upload GameCube artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       if: ${{ matrix.image == 'GameCube' }}
       with: 
         name: VisualBoyAdvanceGX-GameCube


### PR DESCRIPTION
Since GitHub will make obsolete (deprecated) the v2 version of the Upload Artifact Builds, which the workflow used, i decided to update the workflow of GitHub to the latest v3.1.0.