### PR TITLE
Fix a crash upon relaunching after removing a SD/USB device (InfiniteBlueGX)

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -848,7 +848,9 @@ bool LoadPrefs()
 		FixInvalidSettings();
 
 	// attempt to create directories if they don't exist
-	if(GCSettings.LoadMethod == DEVICE_SD || GCSettings.LoadMethod == DEVICE_USB) {
+	if((GCSettings.LoadMethod == DEVICE_SD && ChangeInterface(DEVICE_SD, SILENT))
+		|| (GCSettings.LoadMethod == DEVICE_USB && ChangeInterface(DEVICE_USB, SILENT)))  
+	{
 		char dirPath[MAXPATHLEN];
 		sprintf(dirPath, "%s%s", pathPrefix[GCSettings.LoadMethod], GCSettings.ScreenshotsFolder);
 		CreateDirectory(dirPath);


### PR DESCRIPTION
Seeing that both Snes9x GX and FCEUGX have this fix but not VBAGX, which i see it's really really forgotten, why not carry this fix https://github.com/dborth/fceugx/commit/ca59df2961311eef0cabbc2bb6ed80bc637956d0 from FCEUGX? :)