### PR TITLE
Add Pre-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build VBA GX
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -59,3 +59,40 @@ jobs:
         name: VisualBoyAdvanceGX-GameCube
         path: |
          dist/VisualBoyAdvanceGX-GameCube/
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/master'
+    
+    steps:
+    - uses: actions/checkout@v3
+      name: Download Artifacts
+        
+    - uses: actions/download-artifact@v3
+      with:
+        path: dist
+
+    - name: Re-zip artifacts
+      run: |
+        cd dist
+        rm -r VisualBoyAdvanceGX/vbagx/roms/*
+        rm -r VisualBoyAdvanceGX/vbagx/saves/*
+        zip -r VisualBoyAdvanceGX.zip VisualBoyAdvanceGX
+        zip -r VisualBoyAdvanceGX-GameCube.zip VisualBoyAdvanceGX-GameCube
+
+    - name: Update Git Tag
+      run: |
+        git tag -f Pre-release
+        git push -f origin Pre-release
+
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      with:
+        prerelease: true
+        allowUpdates: true
+        removeArtifacts: true
+        replacesArtifacts: false
+        tag: Pre-release
+        artifacts: "dist/*.zip"


### PR DESCRIPTION
Hi @dborth because the Nightly builds will expire over time I've added a Pre-release under the Releases section:
![image](https://user-images.githubusercontent.com/24655170/205279109-9d587775-3e79-4edf-9d47-f192b4646902.png)

The Pre-release looks like the following, everytime an update to the master branch is triggered it will overwrite the previous Pre-Release. I also removed the cheatsdir, romsdir and savesdir dummy files from the zip file:
![image](https://user-images.githubusercontent.com/24655170/205279141-c1d8af21-dd61-48de-a8c5-59f0f15098bf.png)
