### PR TITLE
Fix MBC7 (specifically Kirby Tilt 'n' Tumble) data saving (Steelskin)

### DIFF
--- a/source/vba/gb/GB.cpp
+++ b/source/vba/gb/GB.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <algorithm>
 
 #include "../System.h"
 #include "../NLS.h"
@@ -2652,6 +2653,9 @@ void gbReset()
   if (gbRomType >= 0x1c && gbRomType<=0x1e)
     gbDataMBC5.isRumbleCartridge = 1;
 
+  memset(&gbDataMBC7, 0, sizeof(gbDataMBC7));
+  gbDataMBC7.mapperROMBank = 1;
+
   memset(&gbDataHuC1, 0, sizeof(gbDataHuC1));
   gbDataHuC1.mapperROMBank = 1;
 
@@ -2821,7 +2825,7 @@ void gbWriteSaveMBC7(const char * name)
       return;
     }
 
-    fwrite(&gbMemory[0xa000],
+    fwrite(gbRam,
            1,
            256,
            file);
@@ -3088,7 +3092,7 @@ bool gbReadSaveMBC7(const char * name)
       return false;
     }
 
-    size_t read = fread(&gbMemory[0xa000],
+    size_t read = fread(gbRam,
                      1,
                      256,
                      file);
@@ -3544,6 +3548,7 @@ static bool gbWriteSaveState(gzFile gzFile)
   utilGzWrite(gzFile, &gbDataMBC2, sizeof(gbDataMBC2));
   utilGzWrite(gzFile, &gbDataMBC3, sizeof(gbDataMBC3));
   utilGzWrite(gzFile, &gbDataMBC5, sizeof(gbDataMBC5));
+  utilGzWrite(gzFile, &gbDataMBC7, sizeof(gbDataMBC7));
   utilGzWrite(gzFile, &gbDataHuC1, sizeof(gbDataHuC1));
   utilGzWrite(gzFile, &gbDataHuC3, sizeof(gbDataHuC3));
   utilGzWrite(gzFile, &gbDataTAMA5, sizeof(gbDataTAMA5));
@@ -3712,6 +3717,7 @@ static bool gbReadSaveState(gzFile gzFile)
   else
     utilGzRead(gzFile, &gbDataMBC3, sizeof(gbDataMBC3));
   utilGzRead(gzFile, &gbDataMBC5, sizeof(gbDataMBC5));
+  utilGzRead(gzFile, &gbDataMBC7, sizeof(gbDataMBC7));
   utilGzRead(gzFile, &gbDataHuC1, sizeof(gbDataHuC1));
   utilGzRead(gzFile, &gbDataHuC3, sizeof(gbDataHuC3));
   if(version>=11)
@@ -4314,7 +4320,8 @@ bool gbUpdateSizes()
   }
 
   if(gbRamSize) {
-    gbRam = (u8 *)malloc(gbRamSize);
+    // Always allocate 4 KiB to prevent access issues down the line.
+    gbRam = (u8 *)malloc(std::max(4096, gbRamSize));
     memset(gbRam, gbRamFill, gbRamSize);
   }
 
@@ -5544,7 +5551,7 @@ int MemgbWriteSaveMBC5(char * membuffer) {
 
 int MemgbWriteSaveMBC7(char * membuffer) {
 	if (gbRam) {
-		memcpy(membuffer, &gbMemory[0xa000], 256);
+		memcpy(membuffer, gbRam, 256);
 		return 256;
 	}
 	return 0;
@@ -5656,7 +5663,7 @@ bool MemgbReadSaveMBC7(char * membuffer, int read) {
 		if (read != 256)
 			return false;
 		else
-			memcpy(&gbMemory[0xa000], membuffer, read);
+			memcpy(gbRam, membuffer, read);
 		return true;
 	}
 	return false;

--- a/source/vba/gb/gbMemory.cpp
+++ b/source/vba/gb/gbMemory.cpp
@@ -719,8 +719,9 @@ void mapperMBC7ROM(u16 address, u8 value)
     if(value < 8) {
       tmpAddress = (value&3) << 13;
       tmpAddress &= gbRamSizeMask;
-      gbMemoryMap[0x0a] = &gbMemory[0xa000];
-      gbMemoryMap[0x0b] = &gbMemory[0xb000];
+      gbMemoryMap[0x0a] = &gbRam[0];
+      // Only one RAM bank for MBC7 so wrap around.
+      gbMemoryMap[0x0b] = &gbRam[0];
 
       gbDataMBC7.mapperRAMBank = value;
       gbDataMBC7.mapperRAMAddress = tmpAddress;
@@ -795,8 +796,8 @@ void mapperMBC7RAM(u16 address, u8 value)
     if(!oldCs && gbDataMBC7.cs) {
       if(gbDataMBC7.state==5) {
         if(gbDataMBC7.writeEnable) {
-          gbMemory[0xa000+gbDataMBC7.address*2]=gbDataMBC7.buffer>>8;
-          gbMemory[0xa000+gbDataMBC7.address*2+1]=gbDataMBC7.buffer&0xff;
+          gbRam[gbDataMBC7.address*2]=gbDataMBC7.buffer>>8;
+          gbRam[gbDataMBC7.address*2+1]=gbDataMBC7.buffer&0xff;
           systemSaveUpdateCounter = SYSTEM_SAVE_UPDATED;
         }
         gbDataMBC7.state=0;
@@ -863,8 +864,8 @@ void mapperMBC7RAM(u16 address, u8 value)
               } else if((gbDataMBC7.address>>6)==1) {
                 if (gbDataMBC7.writeEnable) {
                   for(int i=0;i<256;i++) {
-                    gbMemory[0xa000+i*2] = gbDataMBC7.buffer >> 8;
-                    gbMemory[0xa000+i*2+1] = gbDataMBC7.buffer & 0xff;
+                    gbRam[i*2] = gbDataMBC7.buffer >> 8;
+                    gbRam[i*2+1] = gbDataMBC7.buffer & 0xff;
                     systemSaveUpdateCounter = SYSTEM_SAVE_UPDATED;
                   }
                 }
@@ -872,7 +873,7 @@ void mapperMBC7RAM(u16 address, u8 value)
               } else if((gbDataMBC7.address>>6) == 2) {
                 if (gbDataMBC7.writeEnable) {
                   for(int i=0;i<256;i++)
-                    WRITE16LE((u16 *)&gbMemory[0xa000+i*2], 0xffff);
+                    WRITE16LE((u16 *)&gbRam[i*2], 0xffff);
                   systemSaveUpdateCounter = SYSTEM_SAVE_UPDATED;
                 }
                 gbDataMBC7.state=5;
@@ -894,8 +895,8 @@ void mapperMBC7RAM(u16 address, u8 value)
             if(gbDataMBC7.count==1) {
               gbDataMBC7.state=4;
               gbDataMBC7.count=0;
-              gbDataMBC7.buffer = (gbMemory[0xa000+gbDataMBC7.address*2]<<8)|
-                (gbMemory[0xa000+gbDataMBC7.address*2+1]);
+              gbDataMBC7.buffer = (gbRam[gbDataMBC7.address*2]<<8)|
+                (gbRam[gbDataMBC7.address*2+1]);
             }
             break;
           case 3:

--- a/source/vba/gb/gbMemory.h
+++ b/source/vba/gb/gbMemory.h
@@ -138,6 +138,7 @@ extern mapperMBC1 gbDataMBC1;
 extern mapperMBC2 gbDataMBC2;
 extern mapperMBC3 gbDataMBC3;
 extern mapperMBC5 gbDataMBC5;
+extern mapperMBC7 gbDataMBC7;
 extern mapperHuC1 gbDataHuC1;
 extern mapperHuC3 gbDataHuC3;
 extern mapperTAMA5 gbDataTAMA5;


### PR DESCRIPTION
Commit reference: https://github.com/visualboyadvance-m/visualboyadvance-m/commit/803ab352

Previously, MBC7 EEPROM was saved at address 0xa000 in memory, rather than inside the `gbRam` data buffer. This was inconsistent with other mappers, resulting in issues like the EEPROM data being cleared on `gbReset`.

This fixes specifically the data saving in Kirby: Tilt 'n' Tumble.

Fixes https://github.com/dborth/vbagx/issues/451.