### PR TITLE
Fix MBC2 data saving (F-1 Race, Kirby's Pinball Land, etc.)

### DIFF
--- a/source/vba/gb/GB.cpp
+++ b/source/vba/gb/GB.cpp
@@ -2756,7 +2756,7 @@ void gbWriteSaveMBC2(const char * name)
       return;
     }
 
-    fwrite(&gbMemoryMap[0x0a],
+    fwrite(gbRam,
            1,
            512,
            file);
@@ -2938,7 +2938,7 @@ bool gbReadSaveMBC2(const char * name)
       return false;
     }
 
-    size_t read = fread(&gbMemoryMap[0x0a],
+    size_t read = fread(gbRam,
                      1,
                      512,
                      file);
@@ -5516,8 +5516,8 @@ int MemgbWriteSaveMBC1(char * membuffer) {
 
 int MemgbWriteSaveMBC2(char * membuffer) {
 	if (gbRam) {
-		memcpy(membuffer, &gbMemory[0xa000], 256);
-		return 256;
+		memcpy(membuffer, gbRam, 512);
+		return 512;
 	}
 	return 0;
 }
@@ -5601,10 +5601,10 @@ bool MemgbReadSaveMBC1(char * membuffer, int read) {
 bool MemgbReadSaveMBC2(char * membuffer, int read) {
 	if (gbRam)
 	{
-		if (read != 256)
+		if (read != 512)
 			return false;
 		else
-			memcpy(&gbMemory[0xa000], membuffer, read);
+			memcpy(gbRam, membuffer, read);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Today i've just KO'ed the MBC2 data saving issue that was also plaguing VBA-GX, exactly like MBC7 until very few ago.

The old MBC2 saving routine based on `gbMemory` caused the savedata generated/stored on mapper MBC2 to not saved/stored correctly.

The affected games by this includes **F-1 Race** (story mode progress), **Kirby's Pinball Land** (high scores), etc.

This fixes said issue, by replacing the save routine from `gbMemory` to `gbRam`, like the rest of the mapper saving routines. Also changes the savefile size from 256 kB to 512 kB for avoid saving issues with all MBC2 games.

Based on my MBC7 saving fix https://github.com/dborth/vbagx/commit/51702bb545de762773430147ea92b97db16f1af1, which is also based in the same fix by Steelskin.