### PR TITLE
GB: use upstream MBC2 savedata (saving/loading) handling.

### DIFF
--- a/source/vba/gb/GB.cpp
+++ b/source/vba/gb/GB.cpp
@@ -2756,7 +2756,7 @@ void gbWriteSaveMBC2(const char * name)
       return;
     }
 
-    fwrite(gbRam,
+    fwrite(gbMemoryMap[0x0a],
            1,
            512,
            file);
@@ -2938,7 +2938,7 @@ bool gbReadSaveMBC2(const char * name)
       return false;
     }
 
-    size_t read = fread(gbRam,
+    size_t read = fread(gbMemoryMap[0x0a],
                      1,
                      512,
                      file);
@@ -5516,7 +5516,7 @@ int MemgbWriteSaveMBC1(char * membuffer) {
 
 int MemgbWriteSaveMBC2(char * membuffer) {
 	if (gbRam) {
-		memcpy(membuffer, gbRam, 512);
+		memcpy(membuffer, gbMemoryMap[0x0a], 512);
 		return 512;
 	}
 	return 0;
@@ -5604,7 +5604,7 @@ bool MemgbReadSaveMBC2(char * membuffer, int read) {
 		if (read != 512)
 			return false;
 		else
-			memcpy(gbRam, membuffer, read);
+			memcpy(gbMemoryMap[0x0a], membuffer, read);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
I've taken again some MBC2 savedata handling code from upstream VisualBoyAdvance-M code (instead of that hacky `gbRam` for MBC2 since `gbMemoryMap` for MBC2 doesn't get deleted at reset) before they changed everything to gbCartData, which isn't present in VBA-GX.
`MemgbWriteSave` and `MemgbReadSave` for MBC2, specific functions used on VBA-GX, also have been changed for reflect the new changes.
(See https://github.com/visualboyadvance-m/visualboyadvance-m/blob/9889ef4fa8dfc50fd15591c066f0b9df9411240f/src/gb/GB.cpp for see where did i took this)

I retested F-1 Race, Kirby's Pinball Land, Golf, and a few other MBC2 games, and seems saving/loading is still working since last time i digged into MBC2 savedata handling on VBA-GX.

Currently in further testing, but i will leave this PR as a draft meanwhile.